### PR TITLE
Add explicit templ support, fallback to ft value for filetype on init

### DIFF
--- a/lua/tailwind-fold/config.lua
+++ b/lua/tailwind-fold/config.lua
@@ -9,6 +9,7 @@ M.filetype_to_extension = {
 	php = "php",
 	blade = "blade",
 	eruby = "erb",
+	templ = "templ",
 }
 
 M.class_filetypes = {
@@ -19,6 +20,7 @@ M.class_filetypes = {
 	"vue",
 	"svelte",
 	"astro",
+	"templ",
 }
 
 M.classname_filetypes = {

--- a/lua/tailwind-fold/init.lua
+++ b/lua/tailwind-fold/init.lua
@@ -29,7 +29,7 @@ function M.setup(options)
 
 	local ft_to_pattern = {}
 	for _, ft in ipairs(config.options.ft) do
-		local extension = config.filetype_to_extension[ft]
+		local extension = config.filetype_to_extension[ft] or ft
 		table.insert(ft_to_pattern, "*." .. extension)
 	end
 

--- a/lua/tailwind-fold/utils.lua
+++ b/lua/tailwind-fold/utils.lua
@@ -14,6 +14,7 @@ local supported_filetypes = {
 	"htmldjango",
 	"javascriptreact",
 	"typescriptreact",
+	"templ",
 }
 
 ---@param bufnr number

--- a/queries/templ/class.scm
+++ b/queries/templ/class.scm
@@ -1,0 +1,1 @@
+; inherits: html


### PR DESCRIPTION
See the [associated issue #11](https://github.com/razak17/tailwind-fold.nvim/issues/11)

# What's changed?
- Add explicit support for templ
- Fallback to value of `ft` in init for file extensions, avoiding an error on start

# What hasn't changed?
- templ has not been added to the default config
- README has not been updated to reflect the availability of templ, as I suspect it might be a niche use case.