### PR TITLE
fix: update deprecated vim.validate fn

### DIFF
--- a/lua/tailwind-fold/init.lua
+++ b/lua/tailwind-fold/init.lua
@@ -4,7 +4,7 @@ local config = require("tailwind-fold.config")
 local M = {}
 
 function M.setup(options)
-	vim.validate({ options = { options, "table", true } })
+	vim.validate("options", options, "table", true)
 
 	config.options = vim.tbl_deep_extend("force", config.options, options or {})
 


### PR DESCRIPTION
The vim.validate function has deprecated one of its uses in neovim 0.11.2, which will be removed in neovim 1.0.

This PR updates vim.validate to the new format.